### PR TITLE
Remove duplicate navbar entry for 'header.speakers'

### DIFF
--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -33,7 +33,6 @@ export const menuitems = [
       { title: "header.sessions", path: "/sessions" },
       { title: "header.speakers", path: "/speakers" },
       { title: "header.sprints", path: "/sprints" },
-      { title: "header.speakers", path: "/speakers" },
       { title: "header.attending_menu", path: "/attending" },
     ],
   },


### PR DESCRIPTION
Removed duplicate entry for 'header.speakers' in navbar.

<img width="1416" height="786" alt="image" src="https://github.com/user-attachments/assets/c90f1fa7-2e5c-4e9a-877a-80d3aea3eea9" />
