### PR TITLE
Implement dynamic locale routing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import { autolinkConfig } from "./plugins/rehype-autolink-config";
 import rehypeSlug from "rehype-slug";
 import alpinejs from "@astrojs/alpinejs";
 import icon from "astro-icon";
+import { getSupportedLocales, defaultLang } from "./src/i18n/locales";
 
 // https://astro.build/config
 export default defineConfig({
@@ -29,10 +30,11 @@ export default defineConfig({
 		],
 	},
 	i18n: {
-		locales: ["en", "es"],
-		defaultLocale: "en",
+		locales: getSupportedLocales(),
+		defaultLocale: defaultLang,
 		routing: {
 			prefixDefaultLocale: true,
+			redirectToDefaultLocale: false,
 		},
 	}
 });

--- a/public/js/locale-redirect.js
+++ b/public/js/locale-redirect.js
@@ -1,0 +1,51 @@
+(function () {
+  try {
+    var el = document.currentScript;
+    if (!el) return;
+
+    var supportedAttr = el.getAttribute('data-supported') || '';
+    var supported = supportedAttr
+      .split(',')
+      .map(function (s) { return s.trim().toLowerCase(); })
+      .filter(Boolean);
+    var def = (el.getAttribute('data-default') || 'en').toLowerCase();
+    var template = el.getAttribute('data-path-template') || '/{lang}/';
+
+    // use explicit user preference if present
+    var preferred = null;
+    try {
+      preferred = (localStorage.getItem('preferredLang') || '').toLowerCase();
+    } catch (e) {}
+
+    var chosen = (preferred && supported.indexOf(preferred) !== -1)
+      ? preferred
+      : (function () {
+          // use browser preferences
+          var navLangs = Array.isArray(navigator.languages) && navigator.languages.length
+            ? navigator.languages
+            : [navigator.language || ''];
+          navLangs = navLangs.map(function (l) { return (l || '').toLowerCase(); });
+          var primaries = navLangs.map(function (l) { return l.split('-')[0]; });
+          return primaries.find(function (p) { return supported.indexOf(p) !== -1; }) || def;
+        })();
+
+    var target = template.replace('{lang}', chosen);
+
+    function normalize(p) {
+      // ensure leading slash
+      if (p && p[0] !== '/') p = '/' + p;
+      // normalize trailing slash on pathname-like targets
+      return /\/$/.test(p) ? p : p + '/';
+    }
+
+    var targetNorm = normalize(target);
+    var currentNorm = normalize(location.pathname);
+
+    if (currentNorm !== targetNorm) {
+      try {
+        localStorage.setItem('preferredLang', chosen);
+      } catch (e) {}
+      location.replace(targetNorm);
+    }
+  } catch (e) {}
+})();

--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -97,11 +97,7 @@ export const socials = [
     }
     </div>
     <div class="flex justify-center mt-12 gap-3">
-      <LanguageSelector
-        showFlag={false}
-        languageMapping={{ en: "English", es: "Español" }}
-        class="appearance-none py-1 px-2 rounded bg-slate-100 dark:bg-stone-950"
-      />
+      <LanguageSelector />
       <ThemeSelector />
     </div>
     <div class="mt-4 text-center">

--- a/src/components/languageselector.astro
+++ b/src/components/languageselector.astro
@@ -16,7 +16,7 @@ const { pathname } = Astro.url;
   <Icon name="ion:language" class="w-5 dark:text-white" />
   <label for="language-selector" class="sr-only">Choose a language</label>
 
-  <select onchange="location = this.value;" class="appearance-none cursor-pointer pl-2 pr-2 py-1.5 rounded-md dark:bg-stone-950 dark:text-white focus-visible:outline-none">
+  <select onchange="localStorage.setItem('preferredLang', this.value.split('/')[1]); location = this.value;" class="appearance-none cursor-pointer pl-2 pr-2 py-1.5 rounded-md dark:bg-stone-950 dark:text-white focus-visible:outline-none">
     {
       arrayLangs.map((lang) => {
         let value = localizePath(pathname, lang[0]);

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -174,11 +174,7 @@ export const menuitems = [
         )
       }
     </div>
-	<LanguageSelector
-		showFlag={false}
-		languageMapping={{ en: "EN", es: "ES" }}
-		class="appearance-none py-1 px-2 rounded bg-slate-100 dark:bg-stone-950"
-	/>
+	<LanguageSelector />
 	<ThemeSelector />
     <TicketButton class="mt-4 md:mt-0 hidden md:block" />
   </nav>

--- a/src/components/ui/localeredirect.astro
+++ b/src/components/ui/localeredirect.astro
@@ -1,0 +1,21 @@
+---
+import { getSupportedLocales, defaultLang } from "../../i18n/locales";
+
+export interface Props {
+  // template path with a {lang} token "/{lang}/speakers"
+  pathTemplate: string;
+}
+
+const { pathTemplate } = Astro.props as Props;
+const supported = getSupportedLocales().join(",");
+const fallback = pathTemplate.replace("{lang}", defaultLang);
+---
+
+<!-- script picks best supported lang, noscript falls back to default locale -->
+<script src="/js/locale-redirect.js" data-path-template={pathTemplate} data-supported={supported} data-default={defaultLang}></script>
+<noscript>
+  <meta http-equiv="refresh" content={`0;url=${fallback}`}/>
+  <link rel="canonical" href={fallback} />
+  <meta name="robots" content="noindex" />
+  <p><a href={fallback}>Continue</a></p>
+</noscript>

--- a/src/i18n/locales.ts
+++ b/src/i18n/locales.ts
@@ -1,0 +1,22 @@
+export const languages = {
+  en: "English",
+  es: "Español",
+};
+
+export const defaultLang = "en";
+
+export function getSupportedLocales(): string[] {
+  return Object.keys(languages);
+}
+
+export function getDefaultLang(): string {
+  return defaultLang;
+}
+
+export function getLocaleStaticPaths() {
+  return getSupportedLocales().map((lang) => ({ params: { lang } }));
+}
+
+export function isValidLocale(locale: string): boolean {
+  return getSupportedLocales().includes(locale);
+}

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -1,9 +1,6 @@
-export const languages = {
-  en: "English",
-  es: "Español",
-};
+import { languages, defaultLang } from './locales';
 
-export const defaultLang = "en";
+export { languages, defaultLang };
 export const showDefaultLang = true;
 
 export const ui = {

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,4 +1,5 @@
 import { ui, defaultLang, showDefaultLang } from './ui';
+import { getSupportedLocales } from './locales';
 
 export function getLangFromUrl(url: URL) {
   const [, lang] = url.pathname.split('/');
@@ -54,7 +55,7 @@ export const localizePath = (
   base: string = import.meta.env.BASE_URL
 ): string => {
   if (!locale) {
-    locale = i18next.language;
+    locale = defaultLang;
   }
 
   let pathSegments = path.split("/").filter((segment) => segment !== "");
@@ -74,9 +75,9 @@ export const localizePath = (
 
   let flatRoutes = {};
   let showDefaultLocale = false;
-  const { defaultLocale } = "en";
-  let locales: string[] = ["en", "es"];
-  const { trailingSlash } = "ignore"
+  const defaultLocale = defaultLang;
+  let locales: string[] = getSupportedLocales();
+  const trailingSlash = "ignore";
 
   //if (!locales.includes(locale)) {
   //  console.warn(

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import Footer from "@components/footer.astro";
 import Navbar from "@components/navbar/navbar.astro";
 import "@fontsource-variable/inter";
 import { SEO } from "astro-seo";
+import { defaultLang } from "i18n/locales";
 
 export interface Props {
 	title?: string;
@@ -25,7 +26,7 @@ const makeTitle = title
 ---
 
 <!doctype html>
-<html lang={lang ?? "en"}>
+<html lang={lang ?? defaultLang}>
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />

--- a/src/pages/[...redirect].astro
+++ b/src/pages/[...redirect].astro
@@ -1,0 +1,16 @@
+---
+import LocaleRedirect from "../components/ui/localeredirect.astro";
+
+export async function getStaticPaths() {
+  const pages = import.meta.glob('./en/**/*.astro', { eager: true });
+  const topLevel = Object.keys(pages)
+    .map(path => path.split('/').pop()?.replace('.astro', ''))
+    .filter(Boolean);
+  return topLevel.map((p) => ({ params: { redirect: p } }));
+}
+
+const { redirect } = Astro.params;
+const pathTemplate = `/{lang}/${redirect}`;
+---
+
+<LocaleRedirect pathTemplate={pathTemplate} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,1 +1,5 @@
-<meta http-equiv="refresh" content="0;url=/en/" />
+---
+import LocaleRedirect from "../components/ui/localeredirect.astro";
+---
+
+<LocaleRedirect pathTemplate="/{lang}/" />

--- a/src/pages/session/[...session].astro
+++ b/src/pages/session/[...session].astro
@@ -1,0 +1,15 @@
+---
+import LocaleRedirect from "../../components/ui/localeredirect.astro";
+import Submissions from "../../data/sessions.json";
+
+export async function getStaticPaths() {
+  return Object.values(Submissions).map(s => ({
+    params: { session: s.slug },
+  }));
+}
+
+const { session } = Astro.params;
+const pathTemplate = `/{lang}/session/${session}`;
+---
+
+<LocaleRedirect pathTemplate={pathTemplate} />

--- a/src/pages/speaker/[...slug].astro
+++ b/src/pages/speaker/[...slug].astro
@@ -1,0 +1,15 @@
+---
+import LocaleRedirect from "../../components/ui/localeredirect.astro";
+import SpeakerData from "../../data/speakers.json";
+
+export async function getStaticPaths() {
+  return Object.values(SpeakerData).map(s => ({
+    params: { slug: s.slug },
+  }));
+}
+
+const { slug } = Astro.params;
+const pathTemplate = `/{lang}/speaker/${slug}`;
+---
+
+<LocaleRedirect pathTemplate={pathTemplate} />


### PR DESCRIPTION
- Added dynamic routing based on selected/preferred language e.g. `/session/conference-opening` -> `/[lang]/session/conference-opening`
- Now there is only one source of truth for available languages and the default language instead of hard coding.