### PR TITLE
add skrub to sprint projects

### DIFF
--- a/src/pages/[lang]/sprints.astro
+++ b/src/pages/[lang]/sprints.astro
@@ -15,6 +15,14 @@ const t = useTranslations(lang);
 const { align = "center" } = Astro.props;
 
 const sprintsData = [
+// {
+//  name: "Project ",
+//  project_url: "https://github.com/myossp/project1"
+//  project_doc_url: "https://docs.myossproject.com",
+//  description: "This is an example project that will help you contribute to an OSS initiative!",
+// level: "Beginner friendly, Some math knowledge",
+// languages: "Python, Rust",
+//  },
 {
    name: "Skrub",
    project_url: "https://github.com/skrub-data/skrub/",


### PR DESCRIPTION
This adds https://skrub-data.org/ to the list of projects for the sprint, following the indications from the discord server. Thank you! 