### PR TITLE
Add sprints guide to the sprints website page

### DIFF
--- a/src/pages/[lang]/sprints.astro
+++ b/src/pages/[lang]/sprints.astro
@@ -42,6 +42,8 @@ const sprintsData = [
       <Fragment slot="title">Sprints</Fragment>
       <Fragment slot="description">
       {t("Sprints are informal coding sessions, and knowledge sharing where people gather together to work on Open-Source projects, suggest changes in existing libraries solve problems. A Sprint is an opportunity for learning and self-development while contributing to Open Source projects.")}
+      <br/>
+      <span set:html={t("We encourage maintainers to submit their projects by checking out our <a href=\"https://conference.pyladies.com/docs/speakers/sprints_guide/\" class=\"text-pinkpyladies\" target=\"_blank\">sprints guide</a>.")} />
       </Fragment>
     </Sectionhead>
 


### PR DESCRIPTION
This pull request adds a new sentence with the sprints guide link to the sprints page, so maintainers can easily find out how to submit their project.