### PR TITLE
Fix Layout title from 'Sponsors' to 'Sprints' for sprints page

### DIFF
--- a/src/pages/[lang]/sprints.astro
+++ b/src/pages/[lang]/sprints.astro
@@ -45,7 +45,7 @@ const sprintsData = [
 
 ---
 
-<Layout title="Sponsors">
+<Layout title="Sprints">
   <Container>
     <Sectionhead>
       <Fragment slot="subtitle">{t("Share, learn and contribute!")}</Fragment>


### PR DESCRIPTION
I just noticed that the tab title for the sprints page says "Sponsors". This PR fixes that.