### PR TITLE
adjust avatar images rendering in schedule & save timezone preference in localstorage 

### DIFF
--- a/src/pages/[lang]/schedule.astro
+++ b/src/pages/[lang]/schedule.astro
@@ -742,7 +742,7 @@ const t = useTranslations(lang);
     // Initial update
     updateScrollIndicator();
     updateTimeTooltip();
-    updateTimezoneButtons(); // Esto aplicará el estado guardado
+    updateTimezoneButtons(); // This will apply the saved state
   }
 
   // Call initialization onboth DOMContentLoaded and Astro page load


### PR DESCRIPTION
- Adjust avatar images rendering in schedule
- Adds language info to each talk in schedule
- Saves timezone preference in localstorage - `local` or `utc` 


### Avatars
<img width="600" alt="image" src="https://github.com/user-attachments/assets/00c74501-166a-464a-a58c-e72dbb752714" />

### Localstorage setting
<img width="245" height="121" alt="image" src="https://github.com/user-attachments/assets/1cd3cbea-6ef8-46b7-9099-0d80d53d4c8f" />


Closes #127 