### PR TITLE
Replaced #welcome with #introductions channel.

### DIFF
--- a/locales/el/messages.po
+++ b/locales/el/messages.po
@@ -803,8 +803,8 @@ msgid "The <b>Conference</b> category will be visible once you register, and wil
 msgstr "Η κατηγορία <b>Conference</b> θα είναι ορατή μετά την εγγραφή σας και θα περιλαμβάνει τα παρακάτω κανάλια:"
 
 #: src/pages/[lang]/attending.astro:184
-msgid "<code class=\"text-blue-400\">#welcome</code>, for you to introduce yourself and say hi to others,"
-msgstr "<code class=\"text-blue-400\">#welcome</code>, για να συστηθείτε και να χαιρετήσετε τους υπόλοιπους,"
+msgid "<code class=\"text-blue-400\">#introductions</code>, for you to introduce yourself and say hi to others,"
+msgstr "<code class=\"text-blue-400\">#introductions</code>, για να συστηθείτε και να χαιρετήσετε τους υπόλοιπους,"
 
 #: src/pages/[lang]/attending.astro:185
 msgid "<code class=\"text-blue-400\">#general</code>, for a general conference discussion,"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -988,10 +988,10 @@ msgstr ""
 
 #: src/pages/[lang]/attending.astro:184
 msgid ""
-"<code class=\"text-blue-400\">#welcome</code>, for you to introduce yourself "
+"<code class=\"text-blue-400\">#introductions</code>, for you to introduce yourself "
 "and say hi to others,"
 msgstr ""
-"<code class=\"text-blue-400\">#welcome</code>, para presentarte y saludar a "
+"<code class=\"text-blue-400\">#introductions</code>, para presentarte y saludar a "
 "los demás,"
 
 #: src/pages/[lang]/attending.astro:185

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -996,10 +996,10 @@ msgstr ""
 
 #: src/pages/[lang]/attending.astro:184
 msgid ""
-"<code class=\"text-blue-400\">#welcome</code>, for you to introduce yourself "
+"<code class=\"text-blue-400\">#introductions</code>, for you to introduce yourself "
 "and say hi to others,"
 msgstr ""
-"<code class=\"text-blue-400\">#welcome</code>, pour vous présenter et saluer "
+"<code class=\"text-blue-400\">#introductions</code>, pour vous présenter et saluer "
 "les autres,"
 
 #: src/pages/[lang]/attending.astro:185

--- a/locales/pt/messages.po
+++ b/locales/pt/messages.po
@@ -964,10 +964,10 @@ msgstr ""
 
 #: src/pages/[lang]/attending.astro:184
 msgid ""
-"<code class=\"text-blue-400\">#welcome</code>, for you to introduce yourself "
+"<code class=\"text-blue-400\">#introductions</code>, for you to introduce yourself "
 "and say hi to others,"
 msgstr ""
-"<code class=\"text-blue-400\">#welcome</code>, para te apresentares "
+"<code class=\"text-blue-400\">#introductions</code>, para te apresentares "
 "e dizeres olá aos outros,"
 
 #: src/pages/[lang]/attending.astro:185

--- a/locales/template/messages.pot
+++ b/locales/template/messages.pot
@@ -816,7 +816,7 @@ msgstr ""
 
 #: src/pages/[lang]/attending.astro:184
 msgid ""
-"<code class=\"text-blue-400\">#welcome</code>, for you to introduce "
+"<code class=\"text-blue-400\">#introductions</code>, for you to introduce "
 "yourself and say hi to others,"
 msgstr ""
 

--- a/locales/tr/messages.po
+++ b/locales/tr/messages.po
@@ -945,10 +945,10 @@ msgstr ""
 
 #: src/pages/[lang]/attending.astro:184
 msgid ""
-"<code class=\"text-blue-400\">#welcome</code>, for you to introduce yourself "
+"<code class=\"text-blue-400\">#introductions</code>, for you to introduce yourself "
 "and say hi to others,"
 msgstr ""
-"<code class=\"text-blue-400\">#welcome</code>, kendinizi tanıtmanız ve diğer "
+"<code class=\"text-blue-400\">#introductions</code>, kendinizi tanıtmanız ve diğer "
 "katılımcılara merhaba demeniz için,"
 
 #: src/pages/[lang]/attending.astro:185

--- a/src/pages/[lang]/attending.astro
+++ b/src/pages/[lang]/attending.astro
@@ -181,7 +181,7 @@ const steps = [
         </h3>
         <p set:html={t("The <b>Conference</b> category will be visible once you register, and will contain the following channels:")} />
         <ul class="list-disc pl-10 py-1">
-            <li set:html={t("<code class=\"text-blue-400\">#welcome</code>, for you to introduce yourself and say hi to others,")} />
+            <li set:html={t("<code class=\"text-blue-400\">#introductions</code>, for you to introduce yourself and say hi to others,")} />
             <li set:html={t("<code class=\"text-blue-400\">#general</code>, for a general conference discussion,")} />
             <li set:html={t("<code class=\"text-blue-400\">#networking</code>, so you can share your social media to connect with others,")} />
             <li set:html={t("<code class=\"text-blue-400\">#random</code>, for any discussion not related to the conference,")} />


### PR DESCRIPTION
There's a introductions channel on the Discord that is being used for introductions rather than the welcome channel.